### PR TITLE
Fix Session creation

### DIFF
--- a/KnownLimitations.md
+++ b/KnownLimitations.md
@@ -6,3 +6,4 @@
     > Most of the information in the EOS_UserInfo structure will be empty for non-local users. This is to ensure that EOS does not provide personally identifiable information (PII) to other users. The DisplayName and UserId fields are the only ones the EOS SDK guarantees to populate.
 * OnlineUser::GetUserInfo() retrieves the preferred nickname for the requested user properly, but the underlying user type doesn't store it just yet.
 * Using the Identity interface with connect and the user account doesn't exist, the login will fail completely as there's currently no possibility to use continuance tokens in OSS.
+* The asynchronous login blueprint node doesn't support the changed identity interface. A fix is planned for version 0.3.

--- a/Source/OnlineSubsystemEpic/Private/OnlineSessionInterfaceEpic.cpp
+++ b/Source/OnlineSubsystemEpic/Private/OnlineSessionInterfaceEpic.cpp
@@ -1582,33 +1582,14 @@ bool FOnlineSessionEpic::CreateSession(const FUniqueNetId& HostingPlayerId, FNam
 				this->CreateSessionModificationHandle(NewSessionSettings, modificationHandle, err);
 				if (err.IsEmpty())
 				{
-					// Modify the local session with the modified session options
-					EOS_Sessions_UpdateSessionModificationOptions sessionModificationOptions = {
-						EOS_SESSIONS_UPDATESESSIONMODIFICATION_API_LATEST,
-						TCHAR_TO_UTF8(*SessionName.ToString())
+					// Update the remote session
+					EOS_Sessions_UpdateSessionOptions updateSessionOptions = {
+						EOS_SESSIONS_UPDATESESSION_API_LATEST,
+						modificationHandle
 					};
-					eosResult = EOS_Sessions_UpdateSessionModification(this->sessionsHandle, &sessionModificationOptions, &modificationHandle);
-					if (eosResult == EOS_EResult::EOS_Success)
-					{
-						// Update the remote session
-						EOS_Sessions_UpdateSessionOptions updateSessionOptions = {
-							EOS_SESSIONS_UPDATESESSION_API_LATEST,
-							modificationHandle
-						};
-						EOS_Sessions_UpdateSession(this->sessionsHandle, &updateSessionOptions, this, &FOnlineSessionEpic::OnEOSCreateSessionComplete);
-
-						result = ONLINE_IO_PENDING;
-					}
-					else
-					{
-						char const* resultStr = EOS_EResult_ToString(eosResult);
-						err = FString::Printf(TEXT("[EOS SDK] Error modifying session options - Error Code: %s"), UTF8_TO_TCHAR(resultStr));
-
-						// We failed in creating a new session, so we need to clean up the one we created
-						this->RemoveNamedSession(SessionName);
-
-						result = ONLINE_FAIL;
-					}
+					EOS_Sessions_UpdateSession(this->sessionsHandle, &updateSessionOptions, this, &FOnlineSessionEpic::OnEOSCreateSessionComplete);
+					
+					result = ONLINE_IO_PENDING;
 				}
 			}
 			else


### PR DESCRIPTION
Session creation does not work because of an EOS_NotFound error.

Reason is probably:

2 SessionModificationHandles are being created when creating a session. On top of creating 2 SessionModificationHandles the second one, which gets created with "EOS_Sessions_UpdateSessionModification" (which should only be used if the session already exists) throws the EOS_NotFound error. Removing the second one should fix the problem.

I tested it and the session gets created for me.