### PR TITLE
Add support for connect login and support for external account creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,3 +141,16 @@ While connect also supports EAS as `LoginType`, this is implicitly assumed by th
 `FOnlineAccountCredentials` class has two additional fields, `Id` and `Token`. When using "CONNECT" login flow the `Token` field stores the access token, while the `Id` field holds additional data, that is needed for the Nintendo and Apple login types.
 When using "EAS" as login flow, consult the "OnlineIdentityInterface.h" file to see which field maps to which.
 
+#### Continuance Tokens
+**Note::** This is currently not supported as the EOS SDK gives no possibility to convert a continuance token to and from strings.
+
+When using the connect interface, there might not be a user to login with. The interface remedies that, that it return a continuance token with which the caller can restart the login process. This library supports this in multiple ways.
+In *C++* the OnLoginCompleteDelegate is called regardless if the task completed successful or not. If the original call completed without errors, the delegate will have set the `bWasSuccessful` parameter set to `true` and will contain the local user index, and the users unique net id. If the user doesn't exist but the login process can be restarted by using a continuance token the `bWasSuccessful` parameter is set to `false` and the unique net id will contain the *continuance token*. The process then can be restarted by calling the `IOnlineIdentityInterface::Login(int32, const FOnlineAccountCredentials&)` function, where the `FOnlineAccountCredentials` parameter is initialized with the following parameters:
+* Id: *empty*
+* Token: `<continuance token>`
+* Type: CONNECT::Continuance
+
+If this call succeeds the OnLoginCompleteDelegate is called with the `bWasSuccessful` parameter set to `true`, the local user index, and the users unique net id. Note, that since a continuance token was used to create an account, the unique net id will only contain a product user id and never an epic account id.
+Should the call fail, the delegate will be called with the local user index, the `bWasSuccessful` parameter set to `false`, an invalid net id and an error message.
+
+In *Blueprints* the caller doesn't need to do anything. The BP-Node will take the login details and a boolean asking whether to create a new user. The node then will internally call the appropriate C++ functions.

--- a/Source/OnlineSubsystemEpic/Classes/EpicOnlineServicesLoginTask.cpp
+++ b/Source/OnlineSubsystemEpic/Classes/EpicOnlineServicesLoginTask.cpp
@@ -86,7 +86,7 @@ UEpicOnlineServicesLoginTask* UEpicOnlineServicesLoginTask::TryLogin(ELoginType 
 
 	task->setDelegate(identityInterface);
 
-	task->Credentials.Type = FUtils::GetEnumValueAsString<ELoginType>("ELoginType", loginType);
+	task->Credentials.Type = FString::Printf(TEXT("EAS::%s"), FUtils::GetEnumValueAsString<ELoginType>("ELoginType", loginType));
 
 	switch (loginType)
 	{

--- a/Source/OnlineSubsystemEpic/Classes/EpicOnlineServicesLoginTask.cpp
+++ b/Source/OnlineSubsystemEpic/Classes/EpicOnlineServicesLoginTask.cpp
@@ -9,95 +9,92 @@
 
 IOnlineIdentityPtr UEpicOnlineServicesIdentityTask::GetIdentityInterface()
 {
-	auto world = GetWorld();
+	UWorld* world = GetWorld();
 	IOnlineSubsystem* subsystem = Online::GetSubsystem(world, EPIC_SUBSYSTEM);
 	if (subsystem == nullptr) {
 		return nullptr;
 	}
-	auto interface = subsystem->GetIdentityInterface();
+	IOnlineIdentityPtr interface = subsystem->GetIdentityInterface();
 	if (!interface.IsValid()) {
 		return nullptr;
 	}
 	return interface;
 }
 
-UEpicOnlineServicesLoginTask::UEpicOnlineServicesLoginTask() : LocalUserNum(0)
+// ------------------------------------
+// UEpicOnlineServicesIdentityTask - Login via EOS Auth
+// ------------------------------------
+UEpicOnlineServicesLoginTask::UEpicOnlineServicesLoginTask()
+	: LocalUserNum(0)
 {
 }
 
 void UEpicOnlineServicesLoginTask::OnLoginCompleteDelegate(int32 localUserNum, bool bWasSuccessful, const FUniqueNetId& userId, const FString& errorString)
 {
-	if (!bWasSuccessful) {
-		OnLoginFailure.Broadcast();
+	FString error = errorString;
+	if (bWasSuccessful)
+	{
+		this->OnLoginSuccess.Broadcast();
 	}
-	else {
-		auto interface = this->GetIdentityInterface();
-		auto playerId = interface->GetUniquePlayerId(0);
-		auto PlayerNickName = interface->GetPlayerNickname(0);
-		
-		OnLoginSuccess.Broadcast(playerId->ToString(), PlayerNickName);
+	else
+	{
+		this->OnLoginFailure.Broadcast(errorString);
 	}
+
 	this->EndTask();
 } 
 
 void UEpicOnlineServicesLoginTask::EndTask()
 {
-	auto identityInterface = this->GetIdentityInterface();
-	if (identityInterface != nullptr) {
-		// TODO: Look at the OculusIdentityCallbackProxy.cpp example
-		identityInterface->ClearOnLoginCompleteDelegate_Handle(0, DelegateHandle);
+	if (IOnlineIdentityPtr identityInterface = this->GetIdentityInterface()) 
+	{
+		identityInterface->ClearOnLoginCompleteDelegate_Handle(this->LocalUserNum, DelegateHandle);
 	}
 }
 
 void UEpicOnlineServicesLoginTask::Activate()
 {
-	IOnlineIdentityPtr identityInterface = this->GetIdentityInterface();
-
-	bool result = false;
-
-	if (identityInterface != nullptr) {
-		result = identityInterface->Login(LocalUserNum, Credentials);
+	if (IOnlineIdentityPtr identityInterface = this->GetIdentityInterface())
+	{
+		if (identityInterface->Login(LocalUserNum, Credentials))
+		{
+			// Everything went as planned, return
+			return;
+		}
 	}
 
-	if (!result) {
-		this->OnLoginFailure.Broadcast();
-		this->EndTask();
-	}
-}
-
-void UEpicOnlineServicesLoginTask::setDelegate(IOnlineIdentityPtr identityInterface)
-{
-	this->DelegateHandle = identityInterface->AddOnLoginCompleteDelegate_Handle(
-		LocalUserNum,
-		FOnLoginCompleteDelegate::CreateUObject(this, &UEpicOnlineServicesLoginTask::OnLoginCompleteDelegate)
-	);
+	// Something went wrong, abort
+	this->OnLoginFailure.Broadcast(TEXT("Failed starting login task"));
+	this->EndTask();
 }
 
 UEpicOnlineServicesLoginTask* UEpicOnlineServicesLoginTask::TryLogin(ELoginType loginType, FString id, FString token, int32 localUserNum)
 {
-	auto task = NewObject<UEpicOnlineServicesLoginTask>();
+	UEpicOnlineServicesLoginTask* task = NewObject<UEpicOnlineServicesLoginTask>();
 
 	IOnlineIdentityPtr identityInterface = task->GetIdentityInterface();
-	if (identityInterface == nullptr) {
-		task->OnLoginFailure.Broadcast();
+	if (identityInterface == nullptr) 
+	{
+		task->OnLoginFailure.Broadcast(TEXT("Failed retrieving Identity Interface"));
 		task->EndTask();
 		return nullptr;
 	}
 
-	task->setDelegate(identityInterface);
+	auto loginCompleteDelegate = FOnLoginCompleteDelegate::CreateUObject(task, &UEpicOnlineServicesLoginTask::OnLoginCompleteDelegate);
+	task->DelegateHandle = identityInterface->AddOnLoginCompleteDelegate_Handle(task->LocalUserNum, loginCompleteDelegate);
 
-	task->Credentials.Type = FString::Printf(TEXT("EAS::%s"), FUtils::GetEnumValueAsString<ELoginType>("ELoginType", loginType));
+	task->Credentials.Type = FString::Printf(TEXT("EAS:%s"), *FUtils::GetEnumValueAsString<ELoginType>("ELoginType", loginType));
 
 	switch (loginType)
 	{
 	case ELoginType::AccountPortal:
 	case ELoginType::DeviceCode:
 	case ELoginType::PersistentAuth:
-		task->Credentials.Id = NULL;
-		task->Credentials.Token = NULL;
+		task->Credentials.Id = TEXT("");
+		task->Credentials.Token = TEXT("");
 		break;
 	case ELoginType::ExchangeCode:
-		task->Credentials.Token = NULL;
+		task->Credentials.Token = TEXT("");
 		task->Credentials.Id = id;
 	case ELoginType::Password:
 	case ELoginType::Developer:
@@ -112,4 +109,146 @@ UEpicOnlineServicesLoginTask* UEpicOnlineServicesLoginTask::TryLogin(ELoginType 
 UEpicOnlineServicesLoginTask* UEpicOnlineServicesLoginTask::TryAutoLogin(int32 localUserNum)
 {
 	return UEpicOnlineServicesLoginTask::TryLogin(ELoginType::PersistentAuth, FString(), FString(), localUserNum);
+}
+
+// ------------------------------------
+// UEpicOnlineServicesConnectLoginTask - Login via EOS Connect
+// ------------------------------------
+UEpicOnlineServicesConnectLoginTask* UEpicOnlineServicesConnectLoginTask::TryLogin(int32 LocalUserNum, EConnectLoginType LoginType, FString Id, FString Token, bool CreateNew)
+{
+	UEpicOnlineServicesConnectLoginTask* task = NewObject<UEpicOnlineServicesConnectLoginTask>();
+
+	IOnlineIdentityPtr identityInterface = task->GetIdentityInterface();
+	if (identityInterface == nullptr) 
+	{
+		task->OnLoginFailure.Broadcast(TEXT("Failed retrieving Identity Interface"));
+		task->EndTask();
+		return nullptr;
+	}
+
+	// Set the login delegate
+	auto loginCompleteDelegate = FOnLoginCompleteDelegate::CreateUObject(task, &UEpicOnlineServicesConnectLoginTask::OnLoginCompleteDelegate);
+	task->DelegateHandle = identityInterface->AddOnLoginCompleteDelegate_Handle(LocalUserNum, loginCompleteDelegate);
+
+	// Convert the input argument to credentials
+	task->credentials.Id = Id;
+	task->credentials.Token = Token;
+	task->credentials.Type = FString::Printf(TEXT("CONNECT:%s"), *task->ConnectLoginTypeToString(LoginType));
+
+	// Save if we want to create a new account if we get a continuance token
+	task->createNewAccount = CreateNew;
+
+	return task;
+}
+
+void UEpicOnlineServicesConnectLoginTask::Activate()
+{
+	IOnlineIdentityPtr identityInterface = this->GetIdentityInterface();
+	if (identityInterface)
+	{
+		if (identityInterface->Login(this->localUserIdx, this->credentials))
+		{
+			// Everything went as planned, return
+			return;
+		}
+	}
+
+	// Something went wrong, abort
+	this->OnLoginFailure.Broadcast(TEXT("Failed starting login task"));
+	this->EndTask();
+}
+
+void UEpicOnlineServicesConnectLoginTask::EndTask()
+{
+	if (IOnlineIdentityPtr identityInterface = this->GetIdentityInterface())
+	{
+		identityInterface->ClearOnLoginCompleteDelegate_Handle(this->localUserIdx, DelegateHandle);
+	}
+}
+
+void UEpicOnlineServicesConnectLoginTask::OnLoginCompleteDelegate(int32 localUserNum, bool bWasSuccessful, const FUniqueNetId& userId, const FString& errorString)
+{
+	FString error = errorString;
+	if (bWasSuccessful)
+	{
+		this->OnLoginSuccess.Broadcast();
+	}
+	else
+	{
+		// If the login failed, but we got an FUniqueNetId
+		//  we can use continuance token to restart the process
+		if (userId.IsValid() && this->createNewAccount)
+		{
+			UE_LOG_ONLINE_IDENTITY(Display, TEXT("Restarting login flow with continuance token."));
+
+			IOnlineIdentityPtr identityPtr = this->GetIdentityInterface();
+			
+			FOnlineAccountCredentials contCredentials;
+			contCredentials.Type = TEXT("CONNECT:Continuance");
+			contCredentials.Id = TEXT("");
+			contCredentials.Token = userId.ToString();
+
+			if (identityPtr->Login(localUserNum, contCredentials))
+			{
+				// Everything went well, return
+				return;
+			}
+			else
+			{
+				error = TEXT("Failed restarting login flow with continuance token.");
+			}
+		}
+		else
+		{
+			error = TEXT("User doesn't exist and no new shall be created.");
+		}
+	}
+
+	OnLoginFailure.Broadcast(error);
+	this->EndTask();
+}
+
+FString UEpicOnlineServicesConnectLoginTask::ConnectLoginTypeToString(EConnectLoginType LoginType)
+{
+	switch (LoginType)
+	{
+	case EConnectLoginType::Steam:
+		return TEXT("steam");
+		break;
+	case EConnectLoginType::PSN:
+		return TEXT("psn");
+		break;
+	case EConnectLoginType::XBL:
+		return TEXT("xbl");
+		break;
+	case EConnectLoginType::GOG:
+		return TEXT("gog");
+		break;
+	case EConnectLoginType::Discord:
+		return TEXT("discord");
+		break;
+	case EConnectLoginType::Nintendo:
+		return TEXT("nintendo_id");
+		break;
+	case EConnectLoginType::NintendoNSA:
+		return TEXT("nintendo_nsa");
+		break;
+	case EConnectLoginType::UPlay:
+		return TEXT("uplay");
+		break;
+	case EConnectLoginType::OpenID:
+		return TEXT("openid");
+		break;
+	case EConnectLoginType::DeviceId:
+		return TEXT("device");
+		break;
+	case EConnectLoginType::Apple:
+		return TEXT("apple");
+		break;
+	default:
+		checkNoEntry();
+		break;
+	}
+	
+	return TEXT("");
 }

--- a/Source/OnlineSubsystemEpic/Classes/EpicOnlineServicesLoginTask.h
+++ b/Source/OnlineSubsystemEpic/Classes/EpicOnlineServicesLoginTask.h
@@ -7,8 +7,8 @@
 
 #include "EpicOnlineServicesLoginTask.generated.h"
 
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnLoginSuccess, FString, PlayerId, FString, PlayerNickName);
-DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnLoginFailure);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnLoginSuccess);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnLoginFailure, const FString&, Error);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnLoginRequresMFA);
 
 UCLASS(MinimalAPI)
@@ -24,7 +24,7 @@ protected:
 
 
 /**
- * Blueprint node to manage login workflow
+ * Exposes the epic account login flow to blueprints
  */
 UCLASS(BlueprintType, meta = (ExposedAsyncProxy = AsyncTask))
 class ONLINESUBSYSTEMEPIC_API UEpicOnlineServicesLoginTask : public UEpicOnlineServicesIdentityTask
@@ -43,18 +43,20 @@ public:
 	UPROPERTY(BlueprintAssignable, Category = "Epic Online Services|Identity")
 		FOnLoginFailure OnLoginRequiresMFA;
 
-	// Attempts to login using user supplied credentials
+	/**
+	 * Attempts to log in with the specified epic account login flow and credentials
+	 */
 	UFUNCTION(BlueprintCallable, Category = "Epic Online Services|Identity", meta = (BlueprintInternalUseOnly = "true", DisplayName = "Epic Online Subsystem Login"))
 		static UEpicOnlineServicesLoginTask* TryLogin(ELoginType loginType, FString id, FString token, int32 localUserNum);
-
-	// Attempts to login using locally stored credentials
+	/**
+	 * Attempts to log in with locally stored credentials
+	 */
 	UFUNCTION(BlueprintCallable, Category = "Epic Online Services|Identity", meta = (BlueprintInternalUseOnly = "true", DisplayName = "Epic Online Subsystem Auto Login"))
 		static UEpicOnlineServicesLoginTask* TryAutoLogin(int32 localUserNum);
 
 	/** UBlueprintAsyncActionBase interface */
 	virtual void Activate() override;
 
-	void setDelegate(IOnlineIdentityPtr identityInterface);	
 	FOnlineAccountCredentials Credentials;
 	int32 LocalUserNum;
 private:
@@ -62,4 +64,57 @@ private:
 	void OnLoginCompleteDelegate(int32 localUserNum, bool bWasSuccessful, const FUniqueNetId& userId, const FString& errorString);
 
 	void EndTask();
+};
+
+
+UENUM(BlueprintType)
+enum class EConnectLoginType : uint8
+{
+	Epic,
+	Steam,
+	PSN			UMETA(DisplayName = "Playstation Network (PSN)"),
+	XBL			UMETA(DisplayName = "XBox Live (XBL)"),
+	GOG,
+	Discord,
+	Nintendo,
+	NintendoNSA	UMETA(DisplayName = "Nintendo Service Account"),
+	UPlay,
+	OpenID UMETA(DisplayName = "OpenID Connect"),
+	DeviceId,
+	Apple
+};
+
+/**
+ * Exposes the epic account login flow to blueprints
+ */
+UCLASS(BlueprintType, meta = (ExposedAsyncProxy = AsyncTask))
+class ONLINESUBSYSTEMEPIC_API UEpicOnlineServicesConnectLoginTask 
+	: public UEpicOnlineServicesIdentityTask
+{
+	GENERATED_BODY()
+private:
+	int32 localUserIdx;
+	bool createNewAccount;
+	FOnlineAccountCredentials credentials;
+	
+	void OnLoginCompleteDelegate(int32 localUserNum, bool bWasSuccessful, const FUniqueNetId& userId, const FString& errorString);
+
+	void EndTask();
+
+public:
+
+	UPROPERTY(BlueprintAssignable, Category = "Epic Online Services|Identity")
+		FOnLoginSuccess OnLoginSuccess;
+
+	UPROPERTY(BlueprintAssignable, Category = "Epic Online Services|Identity")
+		FOnLoginFailure OnLoginFailure;
+
+	// Attempts to login using user supplied credentials
+	UFUNCTION(BlueprintCallable, Category = "Epic Online Services|Identity", meta = (BlueprintInternalUseOnly = "true", DisplayName = "Connect Login"))
+		static UEpicOnlineServicesConnectLoginTask* TryLogin(int32 LocalPlayerNum, EConnectLoginType LoginType, FString id, FString token, bool CreateNew);
+
+	FString ConnectLoginTypeToString(EConnectLoginType LoginType);
+
+	/** UBlueprintAsyncActionBase interface */
+	virtual void Activate() override;
 };

--- a/Source/OnlineSubsystemEpic/Private/OnlineIdentityInterfaceEpic.h
+++ b/Source/OnlineSubsystemEpic/Private/OnlineIdentityInterfaceEpic.h
@@ -28,6 +28,8 @@ class FOnlineIdentityInterfaceEpic
 	static void EOS_Connect_OnLoginStatusChanged(EOS_Connect_LoginStatusChangedCallbackInfo const* Data);
 	static void EOS_Auth_OnLoginComplete(EOS_Auth_LoginCallbackInfo const* Data);
 	static void EOS_Auth_OnLogoutComplete(const EOS_Auth_LogoutCallbackInfo* Data);
+	static void EOS_Connect_OnUserCreated(EOS_Connect_CreateUserCallbackInfo const* Data);
+	static void EOS_Connect_OnAccountLinked(EOS_Connect_LinkAccountCallbackInfo const* Data);
 
 	TSharedPtr<FUserOnlineAccount> OnlineUserAcccountFromPUID(EOS_ProductUserId const& PUID) const;
 	ELoginStatus::Type EOSLoginStatusToUELoginStatus(EOS_ELoginStatus LoginStatus);


### PR DESCRIPTION
## Checklist:

- [x] The code follows the style guidelines of this project and the [Epic Coding Standard](https://docs.unrealengine.com/en-US/Programming/Development/CodingStandard/index.html)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings


## Description

Up until now there was no way of login in with EOS Connect through blueprints and now way of creating a new account if the server returned a continuance token.

This PR adds a new blueprint node that gives the user the ability to log in using connect. The node also includes a flag that can be set, which automatically restarts the login process if the login fails and a continuance token is received.
When using the old login node, which only only handles epic accounts this process is not supported as it is assumed that a non existing existing epic account cannot be created through this library.

Note: for now the continuance flow doesn't work as there is no way to convert a continuance token to and from string. The framework is there however, but it will assert as unimplemented when called.

Fixes #27 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update