### PR TITLE
FromString conversion fixes in FUniqueNetIdEpic(FUniqueNetId) constructor

### DIFF
--- a/Source/OnlineSubsystemEpic/Private/OnlineSubsystemEpicTypes.h
+++ b/Source/OnlineSubsystemEpic/Private/OnlineSubsystemEpicTypes.h
@@ -75,27 +75,27 @@ public:
 			else if (type == 1)
 			{
 				char const* buffer = (char const*)(bytes + 1);
-				EOS_ProductUserId puid = EOS_ProductUserId_FromString(buffer);
+				EOS_ProductUserId puid = EOS_ProductUserId_FromString(TCHAR_TO_UTF8(*FString(buffer)));
 				check(EOS_ProductUserId_IsValid(puid));
 				this->productUserId = puid;
 			}
 			else if (type == 2)
 			{
 				char const* buffer = (char const*)(bytes + 1);
-				EOS_EpicAccountId eaid = EOS_EpicAccountId_FromString(buffer);
+				EOS_EpicAccountId eaid = EOS_EpicAccountId_FromString(TCHAR_TO_UTF8(*FString(buffer)));
 				check(EOS_EpicAccountId_IsValid(eaid));
 				this->epicAccountId = eaid;
 			}
 			else if (type == 3)
 			{
 				char const* buffer = (char const*)(bytes + 1);
-				EOS_ProductUserId puid = EOS_ProductUserId_FromString(buffer);
+				EOS_ProductUserId puid = EOS_ProductUserId_FromString(TCHAR_TO_UTF8(*FString(buffer)));
 				check(EOS_ProductUserId_IsValid(puid));
 				this->productUserId = puid;
 
 				// Move the buffer ptr ahead
 				buffer = (char const*)(bytes + 1 + EOS_PRODUCTUSERID_MAX_LENGTH);
-				EOS_EpicAccountId eaid = EOS_EpicAccountId_FromString(buffer);
+				EOS_EpicAccountId eaid = EOS_EpicAccountId_FromString(TCHAR_TO_UTF8(*FString(buffer)));
 				check(EOS_EpicAccountId_IsValid(eaid));
 				this->epicAccountId = eaid;
 			}


### PR DESCRIPTION
Fixed bug where FUniqueNetIdEpic with the FUniqueNetId constructor did not properly create a FUniqueNetIdEpic instance because of lack of null character termination.
